### PR TITLE
Fix invalid string literal in spellcheck script

### DIFF
--- a/spellcheck
+++ b/spellcheck
@@ -32,7 +32,7 @@ function SPELLCHECK_ALL_NAMES() {
   // Determine sheets to scan
   const targets = [];
   // Core tabs
-  ['Player''s Prize-Wall-Points', 'MissionLog', 'Tab/Snacks/StoreCredit', 'StoreCreditLog', 'TournamentResults']
+  ['Player\'s Prize-Wall-Points', 'MissionLog', 'Tab/Snacks/StoreCredit', 'StoreCreditLog', 'TournamentResults']
     .forEach(name => {
       const col = (name === 'TournamentResults') ? 2 : 1;
       if (ss.getSheetByName(name)) targets.push({sheet:name, col});


### PR DESCRIPTION
## Summary
- fix quoting for `Player's Prize-Wall-Points` in sheet list

## Testing
- `node --check spellcheck`


------
https://chatgpt.com/codex/tasks/task_b_685a208674b08320a1790f93db47fdb4